### PR TITLE
Fix sed error on install script when in MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-script: asdf plugin-test clojure https://github.com/halcyon/asdf-clojure.git "clojure -e '(clojure-version)'"
+script: asdf plugin-test clojure "https://github.com/${TRAVIS_REPO_SLUG}" clojure -e '(clojure-version)'
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh

--- a/bin/install
+++ b/bin/install
@@ -24,7 +24,7 @@ installer() {
       cd ${tmp_download_dir}/clojure-tools
       grep -v ruby install.sh > install-without-ruby.sh
       chmod u+x install-without-ruby.sh
-      sed -i "s|PREFIX|${ASDF_INSTALL_PATH}|" clojure
+      sed -i'' -e "s|PREFIX|${ASDF_INSTALL_PATH}|" clojure
       mkdir -p ${ASDF_INSTALL_PATH}
       ./install-without-ruby.sh ${ASDF_INSTALL_PATH}
   ) || (rm -rf ${ASDF_INSTALL_PATH}; exit 1)


### PR DESCRIPTION
Sed on MacOS needs an argument after the `-i` flag
Also adds the `-e` that specifies the sed command to run

Fixes #1