### PR TITLE
Use the repo travis cloned to do the CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
-script: asdf plugin-test clojure https://github.com/${TRAVIS_REPO_SLUG}
+script:
+  - asdf plugin-test clojure $TRAVIS_BUILD_DIR clojure -e '(clojure-version)'
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh


### PR DESCRIPTION
One of the maintainers of `asdf` gave me an awesome tip here asdf-vm/asdf#385 on how to be able to test the plugin repo plus branch with the right changes.

So now we are using the repo cloned by travis ~, with the branch that is being tested.~ :smile: