### PR TITLE
Add Clojure 1.10.1

### DIFF
--- a/bin/versions
+++ b/bin/versions
@@ -1,2 +1,3 @@
 1.9.0 https://download.clojure.org/install/clojure-tools-1.9.0.381.tar.gz
 1.10.0 https://download.clojure.org/install/clojure-tools-1.10.0.403.tar.gz
+1.10.1 https://download.clojure.org/install/clojure-tools-1.10.1.447.tar.gz


### PR DESCRIPTION
Add Clojure [1.10.1](https://www.clojure.org/news/2019/06/06/clojure1-10-1) to the list of versions

