### PR TITLE
Update version 1.10.1 from 1.10.1.469 to 1.10.1.510

### DIFF
--- a/bin/versions
+++ b/bin/versions
@@ -1,3 +1,3 @@
 1.9.0 https://download.clojure.org/install/clojure-tools-1.9.0.381.tar.gz
 1.10.0 https://download.clojure.org/install/clojure-tools-1.10.0.403.tar.gz
-1.10.1 https://download.clojure.org/install/clojure-tools-1.10.1.469.tar.gz
+1.10.1 https://download.clojure.org/install/clojure-tools-1.10.1.510.tar.gz


### PR DESCRIPTION
It may be worth discussing whether this `versions` file should explicitly list each Clojure release, instead of hiding the `y` bit of `x.x.x.y`.